### PR TITLE
Put all base Asset related serialization stuff in the Asset class.

### DIFF
--- a/platypus/assets/Asset.cpp
+++ b/platypus/assets/Asset.cpp
@@ -1,5 +1,7 @@
 #include "Asset.hpp"
+#include "AssetManager.hpp"
 #include "platypus/core/Debug.hpp"
+#include <cstring>
 
 
 namespace platypus
@@ -42,9 +44,39 @@ namespace platypus
         }
     }
 
-    Asset::Asset(size_t uuidPool) :
-        _uuidPool(uuidPool)
+    Asset::Asset(
+        AssetManager* pAssetManager,
+        const std::vector<char>& targetBuffer,
+        size_t bufferPos
+    ) :
+        _uuidPool(pAssetManager->getUUIDPool())
     {
+        PLATYPUS_ASSERT((bufferPos  + asset_base_serialized_size) <= targetBuffer.size());
+
+        const char* pBuf = targetBuffer.data() + bufferPos;
+
+        memcpy(&_type, pBuf, sizeof(AssetType));
+        size_t pos = sizeof(AssetType);
+
+        memcpy(&_id, pBuf + pos, sizeof(UUID_t));
+        pos += sizeof(UUID_t);
+        UUID::occupy(_id, _uuidPool);
+
+        memcpy(&_customFlags, pBuf + pos, asset_metadata_custom_flags_size);
+        pos += asset_metadata_custom_flags_size;
+
+        uint8_t persistent = 0;
+        memcpy(&persistent, pBuf + pos, sizeof(uint8_t));
+        pos += sizeof(uint8_t);
+        _persistent = static_cast<bool>(persistent);
+
+        char name[asset_metadata_name_size];
+        // *the serialized name data is empty at indices that aren't used so no need to set name bytes to 0 here
+        memcpy(name, pBuf + pos, asset_metadata_name_size);
+        _name = std::string(name);
+        pos += asset_metadata_name_size;
+
+        PLATYPUS_ASSERT(pos == asset_base_serialized_size);
     }
 
     Asset::~Asset()
@@ -59,5 +91,46 @@ namespace platypus
             PLATYPUS_ASSERT(false);
         }
         UUID::erase(_id, _uuidPool);
+    }
+
+    /*
+        Serialized format:
+            AssetType _type
+            UUID_t _id
+            uint64_t _customFlags
+            uint8_t _persistent
+            char _name[asset_metadata_name_size];
+    */
+    void Asset::serializeBase(char* pData) const
+    {
+        if (_name.size() >= asset_metadata_name_size)
+        {
+            Debug::log(
+                "Asset name: " + _name + " is too long for serialization! "
+                "Max serialized asset name size is " + std::to_string(asset_metadata_name_size),
+                PLATYPUS_CURRENT_FUNC_NAME,
+                Debug::MessageType::PLATYPUS_ERROR
+            );
+            PLATYPUS_ASSERT(false);
+            return;
+        }
+
+        memcpy(pData, &_type, sizeof(AssetType));
+        size_t pos = sizeof(AssetType);
+
+        memcpy(pData + pos, &_id, sizeof(UUID_t));
+        pos += sizeof(UUID_t);
+
+        memcpy(pData + pos, &_customFlags, sizeof(uint64_t));
+        pos += sizeof(uint64_t);
+
+        uint8_t persistent = static_cast<uint8_t>(_persistent);
+        memcpy(pData + pos, &persistent, sizeof(uint8_t));
+        pos += sizeof(uint8_t);
+
+        char nameData[asset_metadata_name_size];
+        memset(nameData, 0, asset_metadata_name_size);
+        memcpy(nameData, _name.data(), _name.size());
+        memcpy(pData + pos, nameData, asset_metadata_name_size);
     }
 }

--- a/platypus/assets/Asset.hpp
+++ b/platypus/assets/Asset.hpp
@@ -40,6 +40,12 @@ namespace platypus
     constexpr size_t asset_metadata_filepath_size = 64;
     constexpr size_t asset_metadata_custom_flags_size = 8;
 
+    constexpr size_t asset_base_serialized_size = sizeof(AssetType) +
+        sizeof(UUID_t) +
+        asset_metadata_custom_flags_size +
+        sizeof(uint8_t) +
+        asset_metadata_name_size;
+
     class AssetManager;
     class Asset
     {
@@ -62,9 +68,11 @@ namespace platypus
             UUID_t id,
             bool persistent
         );
-        // NOTE: This is used when deserializing asset
-        //  -> derived Asset class sets and occupies the _id, _type and everything else..
-        Asset(size_t uuidPool);
+        Asset(
+            AssetManager* pAssetManager,
+            const std::vector<char>& targetBuffer,
+            size_t bufferPos
+        );
 
         virtual ~Asset();
 
@@ -85,5 +93,10 @@ namespace platypus
         inline void setName(const std::string& name) { _name = name; }
         inline bool isSerializable() const { return _serializable; }
         inline void setSerializable(bool arg) { _serializable = arg; }
+
+    protected:
+        // NOTE: pData must be at least asset_base_serialized_size
+        // TODO: Make safer?
+        void serializeBase(char* pData) const;
     };
 }

--- a/platypus/assets/AssetManager.cpp
+++ b/platypus/assets/AssetManager.cpp
@@ -1229,9 +1229,9 @@ namespace platypus
 
         const char* pBuf = serializedData.data() + bufferReadPos;
 
-        // TODO: Put Asset's _type before _id in its' serialized data to make this less awful here!
         AssetType type;
-        memcpy(&type, pBuf + sizeof(UUID_t), sizeof(AssetType));
+        memcpy(&type, pBuf, sizeof(AssetType));
+        Debug::log("___TEST___attempting to read asset type: " + asset_type_to_string(type));
 
         Asset* pAsset = nullptr;
         switch (type)

--- a/platypus/assets/Image.cpp
+++ b/platypus/assets/Image.cpp
@@ -216,45 +216,18 @@ namespace platypus
         const std::vector<char>& targetBuffer,
         size_t bufferPos
     ) :
-        Asset(pAssetManager->getUUIDPool())
+        Asset(pAssetManager, targetBuffer, bufferPos)
     {
-
-        const size_t serializedSize = sizeof(UUID_t) +
-            sizeof(AssetType) +
-            asset_metadata_custom_flags_size +
-            sizeof(ImageFormat) +
-            sizeof(uint8_t) +
-            asset_metadata_name_size +
-            asset_metadata_filepath_size;
-
+        const size_t serializedSize = getSerializedSize();
         PLATYPUS_ASSERT((bufferPos  + serializedSize) <= targetBuffer.size());
-        uint8_t persistent;
-        char name[asset_metadata_name_size];
-        char filepath[asset_metadata_filepath_size];
 
         const char* pBuf = targetBuffer.data() + bufferPos;
-
-        memcpy(&_id, pBuf, sizeof(UUID_t));
-        UUID::occupy(_id, _uuidPool);
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(&_type, pBuf + pos, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(&_customFlags, pBuf + pos, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        size_t pos = asset_base_serialized_size;
 
         memcpy(&_format, pBuf + pos, sizeof(ImageFormat));
         pos += sizeof(ImageFormat);
 
-        memcpy(&persistent, pBuf + pos, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-        _persistent = static_cast<bool>(persistent);
-
-        memcpy(&name, pBuf + pos, asset_metadata_name_size);
-        pos += asset_metadata_name_size;
-        _name = std::string(name);
-
+        char filepath[asset_metadata_filepath_size];
         memcpy(&filepath, pBuf + pos, asset_metadata_filepath_size);
         pos += asset_metadata_filepath_size;
         _filepath = std::string(filepath);
@@ -528,50 +501,25 @@ namespace platypus
 
     /*
         Serialized format:
-            ID_t assetID;
-            AssetType type
-            uint64_t customFlags;
+            Asset serialized base data
             ImageFormat format;
-            uint8_t persistent;
-            char name[asset_metadata_name_size];
             char filepath[asset_metadata_filepath_size];
     */
     void Image::serialize(
         std::vector<char>& targetBuffer
     ) const
     {
-        PLATYPUS_ASSERT(_name.size() <= asset_metadata_name_size);
         PLATYPUS_ASSERT(_filepath.size() <= asset_metadata_filepath_size);
         const size_t prevSize = targetBuffer.size();
         const size_t serializedSize = getSerializedSize();
         targetBuffer.resize(prevSize + serializedSize);
+
         char* pBuf = targetBuffer.data() + prevSize;
-
-        UUID_t useID = _id;
-        if (this == Application::get_instance()->getAssetManager()->getErrorImage())
-            useID = NULL_UUID;
-
-        memcpy(pBuf, &useID, sizeof(UUID_t));
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(pBuf + pos, &_type, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(pBuf + pos, &_customFlags, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        serializeBase(pBuf);
+        size_t pos = asset_base_serialized_size;
 
         memcpy(pBuf + pos, &_format, sizeof(ImageFormat));
         pos += sizeof(ImageFormat);
-
-        const uint8_t persistent = static_cast<const uint8_t>(_persistent);
-        memcpy(pBuf + pos, &persistent, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-
-        // Clear the buf for the longest possible name
-        memset(pBuf + pos, 0, asset_metadata_name_size);
-        // Write the name
-        memcpy(pBuf + pos, _name.data(), _name.size());
-        pos += asset_metadata_name_size;
 
         // Same as above for the filepath
         memset(pBuf + pos, 0, asset_metadata_filepath_size);
@@ -583,12 +531,8 @@ namespace platypus
 
     size_t Image::getSerializedSize() const
     {
-        return sizeof(UUID_t) +
-            sizeof(AssetType) +
-            asset_metadata_custom_flags_size +
+        return asset_base_serialized_size +
             sizeof(ImageFormat) +
-            sizeof(uint8_t) +
-            asset_metadata_name_size +
             asset_metadata_filepath_size;
     }
 }

--- a/platypus/assets/Material.cpp
+++ b/platypus/assets/Material.cpp
@@ -109,10 +109,10 @@ namespace platypus
         const std::vector<char>& targetBuffer,
         size_t bufferPos
     ) :
-        Asset(pAssetManager->getUUIDPool())
+        Asset(pAssetManager, targetBuffer, bufferPos)
     {
         const size_t serializedSize = getSerializedSize();
-        PLATYPUS_ASSERT((bufferPos  + serializedSize) <= targetBuffer.size());
+        PLATYPUS_ASSERT((bufferPos + serializedSize) <= targetBuffer.size());
 
         float specularStrength;
         float shininess;
@@ -122,20 +122,9 @@ namespace platypus
         uint8_t receiveShadows;
         uint8_t transparent;
         uint8_t shadeless;
-        uint8_t persistent;
-        char name[asset_metadata_name_size];
 
         const char* pBuf = targetBuffer.data() + bufferPos;
-
-        memcpy(&_id, pBuf, sizeof(UUID_t));
-        UUID::occupy(_id, _uuidPool);
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(&_type, pBuf + pos, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(&_customFlags, pBuf + pos, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        size_t pos = asset_base_serialized_size;
 
         memcpy(&specularStrength, pBuf + pos, sizeof(float));
         pos += sizeof(float);
@@ -165,10 +154,6 @@ namespace platypus
         pos += sizeof(uint8_t);
         _shadeless = static_cast<bool>(shadeless);
 
-        memcpy(&persistent, pBuf + pos, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-        _persistent = static_cast<bool>(persistent);
-
         memcpy(&_blendmapTextureID, pBuf + pos, sizeof(UUID_t));
         pos += sizeof(UUID_t);
 
@@ -190,10 +175,6 @@ namespace platypus
             if (_normalTextureIDs[i] != NULL_UUID)
                 ++_normalTextureCount;
         }
-
-        memcpy(&name, pBuf + pos, asset_metadata_name_size);
-        pos += asset_metadata_name_size;
-        _name = std::string(name);
 
         PLATYPUS_ASSERT(pos == serializedSize);
 
@@ -849,9 +830,8 @@ namespace platypus
 
     /*
         Serialized format:
-            ID_t assetID
-            AssetType type
-            uint64_t customFlags
+            Asset serialized base data
+
             float specularStrength
             float shininess
             Vector2f textureOffset
@@ -860,12 +840,10 @@ namespace platypus
             uint8_t receiveShadows
             uint8_t transparent
             uint8_t shadeless
-            uint8_t persistent
-            ID_t blendmapTextureID
-            ID_t diffuseTextureIDs[PE_MAX_MATERIAL_TEX_CHANNELS]
-            ID_t specularTextureIDs[PE_MAX_MATERIAL_TEX_CHANNELS]
-            ID_t normalTextureIDs[PE_MAX_MATERIAL_TEX_CHANNELS]
-            char name[metadata_name_size]
+            UUID_t blendmapTextureID
+            UUID_t diffuseTextureIDs[PE_MAX_MATERIAL_TEX_CHANNELS]
+            UUID_t specularTextureIDs[PE_MAX_MATERIAL_TEX_CHANNELS]
+            UUID_t normalTextureIDs[PE_MAX_MATERIAL_TEX_CHANNELS]
     */
     void Material::serialize(
         std::vector<char>& targetBuffer
@@ -878,14 +856,8 @@ namespace platypus
         targetBuffer.resize(prevSize + serializedSize);
         char* pBuf = targetBuffer.data() + prevSize;
 
-        memcpy(pBuf, &_id, sizeof(UUID_t));
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(pBuf + pos, &_type, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(pBuf + pos, &_customFlags, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        serializeBase(pBuf);
+        size_t pos = asset_base_serialized_size;
 
         const float specularStrength = getSpecularStrength();
         memcpy(pBuf + pos, &specularStrength, sizeof(float));
@@ -917,10 +889,6 @@ namespace platypus
 
         const uint8_t shadeless = static_cast<uint8_t>(_shadeless);
         memcpy(pBuf + pos, &shadeless, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-
-        const uint8_t persistent = static_cast<const uint8_t>(_persistent);
-        memcpy(pBuf + pos, &persistent, sizeof(uint8_t));
         pos += sizeof(uint8_t);
 
         UUID_t useBlendmapID = _blendmapTextureID;
@@ -960,24 +928,34 @@ namespace platypus
         memcpy(pBuf + pos, &useNormalTextureIDs, textureChannelSize);
         pos += textureChannelSize;
 
-        memset(pBuf + pos, 0, asset_metadata_name_size);
-        memcpy(pBuf + pos, _name.data(), _name.size());
-        pos += asset_metadata_name_size;
-
         PLATYPUS_ASSERT(pos == serializedSize);
     }
 
     size_t Material::getSerializedSize() const
     {
-        return sizeof(UUID_t) +
-            sizeof(AssetType) +
-            asset_metadata_custom_flags_size +
-            sizeof(float) * 2 +
-            sizeof(Vector2f) * 2 +
-            sizeof(uint8_t) * 5 +
-            sizeof(UUID_t) +
-            sizeof(UUID_t) * PE_MAX_MATERIAL_TEX_CHANNELS * 3 +
-            asset_metadata_name_size;
+        return asset_base_serialized_size +
+            sizeof(float) + // specularStrength
+            sizeof(float) + // shininess
+            sizeof(Vector2f) + // textureOffset
+            sizeof(Vector2f) + // textureScale
+            sizeof(uint8_t) + // castShadows
+            sizeof(uint8_t) + // receiveShadows
+            sizeof(uint8_t) + // transparent
+            sizeof(uint8_t) + // shadeless
+            sizeof(UUID_t) +  // blendmapTextureID
+            sizeof(UUID_t) * PE_MATERIAL_TEX_CHANNEL_SLOTS + // diffuseTextureIDs[PE_MATERIAL_TEX_CHANNEL_SLOTS]
+            sizeof(UUID_t) * PE_MATERIAL_TEX_CHANNEL_SLOTS + // specularTextureIDs[PE_MATERIAL_TEX_CHANNEL_SLOTS]
+            sizeof(UUID_t) * PE_MATERIAL_TEX_CHANNEL_SLOTS;  // normalTextureIDs[PE_MATERIAL_TEX_CHANNEL_SLOTS]
+
+        //return sizeof(UUID_t) +
+        //    sizeof(AssetType) +
+        //    asset_metadata_custom_flags_size +
+        //    sizeof(float) * 2 +
+        //    sizeof(Vector2f) * 2 +
+        //    sizeof(uint8_t) * 5 +
+        //    sizeof(UUID_t) +
+        //    sizeof(UUID_t) * PE_MAX_MATERIAL_TEX_CHANNELS * 3 +
+        //    asset_metadata_name_size;
     }
 
     void Material::warnUnassigned(const std::string& beginStr)

--- a/platypus/assets/Mesh.cpp
+++ b/platypus/assets/Mesh.cpp
@@ -53,75 +53,33 @@ namespace platypus
         _animations = animations;
     }
 
-    /*
-        Serialized format (in order):
-            UUID_t assetID
-            AssetType type
-            uint64_t customFlags
-            uint32_t meshPropertyFlags
-            uint8_t persistent
-            uint8_t store hostside buffers on deserialization
-            char name[asset_metadata_name_size]
-            uint32_t vertexBufferDataSize
-            uint32_t indexBufferDataSize
-            IndexType indexType
-
-            VertexBufferLayout serialized vbLayout data
-
-            char vertexBufferData[vertexBufferSerializedSize]
-            char indexBufferData[indexBufferSerializedSize]
-    */
     Mesh::Mesh(
         AssetManager* pAssetManager,
         const std::vector<char>& targetBuffer,
         size_t bufferPos
     ) :
-        Asset(pAssetManager->getUUIDPool())
+        Asset(pAssetManager, targetBuffer, bufferPos)
     {
-        uint8_t persistent = 0;
         uint8_t storeHostsideBuffersOnDeserialization = 0;
-        char name[asset_metadata_name_size];
         uint32_t vertexBufferSize = 0;
         uint32_t indexBufferSize = 0;
         IndexType indexType;
-        const size_t baseSize = sizeof(UUID_t) +
-            sizeof(AssetType) +
-            sizeof(uint64_t) +
-            sizeof(uint32_t) +
+        const size_t baseMeshSize = sizeof(uint32_t) +
             sizeof(uint8_t) +
-            sizeof(uint8_t) +
-            asset_metadata_name_size+
-            sizeof(uint32_t) +
-            sizeof(uint32_t) +
+            sizeof(uint32_t) * 2 +
             sizeof(IndexType);
 
-        PLATYPUS_ASSERT(bufferPos + baseSize < targetBuffer.size());
+        PLATYPUS_ASSERT(bufferPos + asset_base_serialized_size + baseMeshSize < targetBuffer.size());
 
         const char* pBuf = targetBuffer.data() + bufferPos;
-        memcpy(&_id, pBuf, sizeof(UUID_t));
-        UUID::occupy(_id, _uuidPool);
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(&_type, pBuf + pos, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(&_customFlags, pBuf + pos, sizeof(uint64_t));
-        pos += sizeof(uint64_t);
+        size_t pos = asset_base_serialized_size;
 
         memcpy(&_propertyFlags, pBuf + pos, sizeof(uint32_t));
         pos += sizeof(uint32_t);
 
-        memcpy(&persistent, pBuf + pos, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-        _persistent = static_cast<bool>(persistent);
-
         memcpy(&storeHostsideBuffersOnDeserialization, pBuf + pos, sizeof(uint8_t));
         pos += sizeof(uint8_t);
         _storeHostsideBuffersOnDeserialization = static_cast<bool>(storeHostsideBuffersOnDeserialization);
-
-        memcpy(&name, pBuf + pos, asset_metadata_name_size);
-        pos += asset_metadata_name_size;
-        _name = std::string(name);
 
         memcpy(&vertexBufferSize, pBuf + pos, sizeof(uint32_t));
         pos += sizeof(uint32_t);
@@ -134,7 +92,7 @@ namespace platypus
 
         VertexBufferLayout vertexBufferLayout = VertexBufferLayout::deserialize(
             targetBuffer,
-            bufferPos + baseSize
+            bufferPos + asset_base_serialized_size + baseMeshSize
         );
         pos += vertexBufferLayout.getSerializedSize();
 
@@ -397,13 +355,10 @@ namespace platypus
 
     /*
         Serialized format:
-            UUID_t assetID
-            AssetType type
-            uint64_t customFlags
+            Asset serialized base data
+
             uint32_t meshPropertyFlags
-            uint8_t persistent
             uint8_t store hostside buffers on deserialization
-            char name[asset_metadata_name_size]
             uint32_t vertexBufferDataSize
             uint32_t indexBufferDataSize
             IndexType indexType
@@ -453,31 +408,16 @@ namespace platypus
         targetBuffer.resize(prevSize + serializedSize);
 
         char* pBuf = targetBuffer.data() + prevSize;
-        memcpy(pBuf, &_id, sizeof(UUID_t));
-        size_t pos = sizeof(UUID_t);
 
-        memcpy(pBuf + pos, &_type, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(pBuf + pos, &_customFlags, sizeof(uint64_t));
-        pos += sizeof(uint64_t);
+        serializeBase(pBuf);
+        size_t pos = asset_base_serialized_size;
 
         memcpy(pBuf + pos, &_propertyFlags, sizeof(uint32_t));
         pos += sizeof(uint32_t);
 
-        const uint8_t persistent = static_cast<const uint8_t>(_persistent);
-        memcpy(pBuf + pos, &persistent, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-
         const uint8_t storeHostsideBuffersOnDeserialization = static_cast<const uint8_t>(_storeHostsideBuffersOnDeserialization);
         memcpy(pBuf + pos, &storeHostsideBuffersOnDeserialization, sizeof(uint8_t));
         pos += sizeof(uint8_t);
-
-        // Clear the buf for the longest possible name
-        memset(pBuf + pos, 0, asset_metadata_name_size);
-        // Write the name
-        memcpy(pBuf + pos, _name.data(), _name.size());
-        pos += asset_metadata_name_size;
 
         const size_t vertexBufferSize = _pVertexBuffer->getTotalSize();
         const uint32_t vertexBufferSizeU32 = static_cast<uint32_t>(vertexBufferSize);
@@ -524,16 +464,12 @@ namespace platypus
 
     size_t Mesh::getSerializedSize() const
     {
-        return sizeof(UUID_t) +
-            sizeof(AssetType) +
-            asset_metadata_custom_flags_size +
+        return asset_base_serialized_size +
             sizeof(uint32_t) + // meshPropertyFlags
-            sizeof(uint8_t) + // persistent
             sizeof(uint8_t) + // store hostside buffers on deserialization
-            asset_metadata_name_size +
-            sizeof(uint32_t) + // vertexBufferData size
-            sizeof(uint32_t) + // indexBufferData size
-            sizeof(IndexType) + // index type
+            sizeof(uint32_t) + // vertexBufferDataSize
+            sizeof(uint32_t) + // indexBufferDataSize
+            sizeof(IndexType) + // indexType
             _vertexBufferLayout.getSerializedSize() +
             _pVertexBuffer->getTotalSize() +
             _pIndexBuffer->getTotalSize();

--- a/platypus/assets/Model.cpp
+++ b/platypus/assets/Model.cpp
@@ -27,49 +27,31 @@ namespace platypus
         const std::vector<char>& targetBuffer,
         size_t bufferPos
     ) :
-        Asset(pAssetManager->getUUIDPool())
+        Asset(pAssetManager, targetBuffer, bufferPos)
     {
-        const size_t serializedSize = getSerializedSize();
-        PLATYPUS_ASSERT((bufferPos  + serializedSize) <= targetBuffer.size());
+        const size_t serializedModelBaseSize = asset_base_serialized_size +
+            sizeof(uint8_t) +
+            sizeof(uint32_t);
+
+        PLATYPUS_ASSERT((bufferPos + serializedModelBaseSize) <= targetBuffer.size());
 
         uint8_t instanced;
-        uint8_t persistent;
         uint32_t meshCount;
-        char name[asset_metadata_name_size];
         char filepath[asset_metadata_filepath_size];
 
         const char* pBuf = targetBuffer.data() + bufferPos;
-
-        memcpy(&_id, pBuf, sizeof(UUID_t));
-        UUID::occupy(_id, _uuidPool);
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(&_type, pBuf + pos, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(&_customFlags, pBuf + pos, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        size_t pos = asset_base_serialized_size;
 
         memcpy(&instanced, pBuf + pos, sizeof(uint8_t));
         pos += sizeof(uint8_t);
         _instanced = static_cast<bool>(instanced);
 
-        memcpy(&persistent, pBuf + pos, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-        _persistent = static_cast<bool>(persistent);
-
         memcpy(&meshCount, pBuf + pos, sizeof(uint32_t));
         pos += sizeof(uint32_t);
-
-        memcpy(&name, pBuf + pos, asset_metadata_name_size);
-        pos += asset_metadata_name_size;
-        _name = std::string(name);
 
         memcpy(&filepath, pBuf + pos, asset_metadata_filepath_size);
         pos += asset_metadata_filepath_size;
         _filepath = std::string(filepath);
-
-        PLATYPUS_ASSERT(pos == serializedSize);
 
         _meshes.resize(meshCount);
         memset(_meshes.data(), 0, sizeof(Mesh*) * meshCount);
@@ -90,50 +72,33 @@ namespace platypus
 
     /*
         Serialized format:
-            UUID_t assetID
-            AssetType type
-            uint64_t customFlags
+            Asset serialized base data
+
             uint8_t instanced
-            uint8_t persistent
             uint32_t meshCount
-            char name[metadata_name_size]
-            char filepath[metadata_filepath_size]
+            char filepath[asset_metadata_filepath_size]
             UUID_t meshIDs[meshCount]
     */
     void Model::serialize(
         std::vector<char>& targetBuffer
     ) const
     {
-        PLATYPUS_ASSERT(_name.size() <= asset_metadata_name_size);
         PLATYPUS_ASSERT(_filepath.size() <= asset_metadata_filepath_size);
         const size_t serializedSize = getSerializedSize();
         const size_t prevSize = targetBuffer.size();
         targetBuffer.resize(prevSize + serializedSize);
         char* pBuf = targetBuffer.data() + prevSize;
 
-        memcpy(pBuf, &_id, sizeof(UUID_t));
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(pBuf + pos, &_type, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(pBuf + pos, &_customFlags, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        serializeBase(pBuf);
+        size_t pos = asset_base_serialized_size;
 
         const uint8_t instanced = static_cast<uint8_t>(_instanced);
         memcpy(pBuf + pos, &instanced, sizeof(uint8_t));
         pos += sizeof(uint8_t);
 
-        const uint8_t persistent = static_cast<const uint8_t>(_persistent);
-        memcpy(pBuf + pos, &persistent, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-
         const uint32_t meshCount = static_cast<const uint32_t>(_meshes.size());
         memcpy(pBuf + pos, &meshCount, sizeof(uint32_t));
         pos += sizeof(uint32_t);
-
-        memcpy(pBuf + pos, _name.data(), _name.size());
-        pos += asset_metadata_name_size;
 
         memcpy(pBuf + pos, _filepath.data(), _filepath.size());
         pos += asset_metadata_filepath_size;
@@ -150,14 +115,10 @@ namespace platypus
 
     size_t Model::getSerializedSize() const
     {
-        // 122?
-        return sizeof(UUID_t) +
-            sizeof(AssetType) +
-            asset_metadata_custom_flags_size +
-            sizeof(uint8_t) * 2 +
-            sizeof(uint32_t) +
-            asset_metadata_name_size +
-            asset_metadata_filepath_size +
-            sizeof(UUID_t) * _meshes.size();
+        return asset_base_serialized_size +
+            sizeof(uint8_t) + // instanced
+            sizeof(uint32_t) + // meshCount
+            sizeof(char) * asset_metadata_filepath_size + // filepath[metadata_filepath_size]
+            sizeof(UUID_t) * _meshes.size(); //  meshIDs[meshCount]
     }
 }

--- a/platypus/assets/Texture.cpp
+++ b/platypus/assets/Texture.cpp
@@ -32,21 +32,13 @@ namespace platypus
         const std::vector<char>& targetBuffer,
         size_t bufferPos
     ) :
-        Asset(pAssetManager->getUUIDPool())
+        Asset(pAssetManager, targetBuffer, bufferPos)
     {
         const size_t serializedSize = getSerializedSize();
-        PLATYPUS_ASSERT((bufferPos + serializedSize) <= targetBuffer.size());
+        PLATYPUS_ASSERT((bufferPos + asset_base_serialized_size + serializedSize) <= targetBuffer.size());
 
         const char* pBuf = targetBuffer.data() + bufferPos;
-        memcpy(&_id, pBuf, sizeof(UUID_t));
-        UUID::occupy(_id, _uuidPool);
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(&_type, pBuf + pos, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(&_customFlags, pBuf + pos, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        size_t pos = asset_base_serialized_size;
 
         UUID_t imageUUID;
         memcpy(&imageUUID, pBuf + pos, sizeof(UUID_t));
@@ -65,21 +57,13 @@ namespace platypus
         memcpy(&useMipmapping, pBuf + pos, sizeof(uint8_t));
         pos += sizeof(uint8_t);
 
+        PLATYPUS_ASSERT(pos == serializedSize);
+
         _pSampler = pAssetManager->getOrCreateTextureSampler(
             filterMode,
             addressMode,
             static_cast<bool>(useMipmapping)
         );
-
-        // TODO: Put all "pure Asset" related stuff in the beginning instead!
-        uint8_t persistent;
-        memcpy(&persistent, pBuf + pos, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-        _persistent = static_cast<bool>(persistent);
-
-        char name[asset_metadata_name_size];
-        memcpy(name, pBuf + pos, asset_metadata_name_size);
-        _name = std::string(name);
 
         pAssetManager->addExternalAsset(this);
         if (_persistent)
@@ -138,21 +122,17 @@ namespace platypus
 
     /*
         Serialized format:
-            ID_t assetID
-            AssetType type
-            uint64_t customFlags
-            ID_t imageID
+            Asset serialized base data
+
+            UUID_t imageID
             TextureSamplerFilterMode filterMode
             TextureSamplerAddressMode addressMode
             uint8_t useMipmapping
-            uint8_t persistent
-            char name[metadata_name_size]
     */
     void Texture::serialize(
         std::vector<char>& targetBuffer
     ) const
     {
-        PLATYPUS_ASSERT(_name.size() <= asset_metadata_name_size);
         PLATYPUS_ASSERT(_pImage);
         PLATYPUS_ASSERT(_pImage->getID() != NULL_UUID);
 
@@ -161,14 +141,8 @@ namespace platypus
         targetBuffer.resize(prevSize + serializedSize);
         char* pBuf = targetBuffer.data() + prevSize;
 
-        memcpy(pBuf, &_id, sizeof(UUID_t));
-        size_t pos = sizeof(UUID_t);
-
-        memcpy(pBuf + pos, &_type, sizeof(AssetType));
-        pos += sizeof(AssetType);
-
-        memcpy(pBuf + pos, &_customFlags, asset_metadata_custom_flags_size);
-        pos += asset_metadata_custom_flags_size;
+        serializeBase(pBuf);
+        size_t pos = asset_base_serialized_size;
 
         UUID_t imageID = _pImage->getID();
         AssetManager* pAssetManager = Application::get_instance()->getAssetManager();
@@ -190,29 +164,16 @@ namespace platypus
         memcpy(pBuf + pos, &useMipmapping, sizeof(uint8_t));
         pos += sizeof(uint8_t);
 
-        const uint8_t persistent = static_cast<const uint8_t>(_persistent);
-        memcpy(pBuf + pos, &persistent, sizeof(uint8_t));
-        pos += sizeof(uint8_t);
-
-        // Clear the buf for the longest possible name
-        memset(pBuf + pos, 0, asset_metadata_name_size);
-        // Write the name
-        memcpy(pBuf + pos, _name.data(), _name.size());
-        pos += asset_metadata_name_size;
-
         PLATYPUS_ASSERT(pos == serializedSize);
     }
 
     size_t Texture::getSerializedSize() const
     {
-        return sizeof(UUID_t) +
-            sizeof(AssetType) +
-            asset_metadata_custom_flags_size +
-            sizeof(UUID_t) +
-            sizeof(TextureSamplerFilterMode) +
-            sizeof(TextureSamplerAddressMode) +
-            sizeof(uint8_t) * 2 +
-            asset_metadata_name_size;
+        return asset_base_serialized_size +
+            sizeof(UUID_t) + // imageID
+            sizeof(TextureSamplerFilterMode) + //  filterMode
+            sizeof(TextureSamplerAddressMode) + //  addressMode
+            sizeof(uint8_t); //  useMipmapping
     }
 
     void Texture::fixMaterialsOnDestruction()


### PR DESCRIPTION
Made Asset serialization a little more coherent..