### PR TITLE
Entity name improvements

### DIFF
--- a/platypus/core/Scene.cpp
+++ b/platypus/core/Scene.cpp
@@ -130,15 +130,6 @@ namespace platypus
 
         if (!name.empty())
         {
-            if (_nameEntityMapping.find(name) != _nameEntityMapping.end())
-            {
-                Debug::log(
-                    "Entity name: " + name + " already exists!",
-                    PLATYPUS_CURRENT_FUNC_NAME,
-                    Debug::MessageType::PLATYPUS_ERROR
-                );
-                PLATYPUS_ASSERT(false);
-            }
             // Not allowing spaces in name atm!
             if (name.find(" ") != std::string::npos)
             {
@@ -158,16 +149,17 @@ namespace platypus
             _freeEntityIDs.pop();
 
             entity.id = freeID;
-            _entities[freeID] = entity;
+            const size_t freeIndex = static_cast<const size_t>(freeID);
+            _entities[freeIndex] = entity;
         }
         else
         {
-            entity.id = _entities.size();
+            entity.id = static_cast<entityID_t>(_entities.size());
             _entities.push_back(entity);
         }
 
         if (!name.empty())
-            _nameEntityMapping[name] = entity.id;
+            _entityNameMapping[static_cast<const size_t>(entity.id)] = name;
 
         return entity.id;
     }
@@ -195,101 +187,18 @@ namespace platypus
         return { };
     }
 
-    Entity Scene::getEntity(const std::string& name) const
-    {
-        std::unordered_map<std::string, size_t>::const_iterator it = _nameEntityMapping.find(name);
-        if (it != _nameEntityMapping.end())
-            return getEntity(static_cast<entityID_t>(it->second));
-
-        return { };
-    }
-
     std::string Scene::getEntityName(entityID_t entity) const
     {
-        if (entity == NULL_ENTITY_ID)
-            return "";
+        std::unordered_map<entityID_t, std::string>::const_iterator it = _entityNameMapping.find(entity);
+        if (it != _entityNameMapping.end())
+            return it->second;
 
-        std::unordered_map<std::string, size_t>::const_iterator it;
-        for (it = _nameEntityMapping.begin(); it != _nameEntityMapping.end(); ++it)
-        {
-            if (it->second == static_cast<size_t>(entity))
-                return it->first;
-        }
         return "";
     }
 
-    void Scene::setEntityName(const std::string& currentName, const std::string& newName)
+    void Scene::setEntityName(entityID_t entity, const std::string& name)
     {
-        // Not allowing spaces in name atm!
-        if (newName.find(" ") != std::string::npos)
-        {
-            Debug::log(
-                "Invalid entity name: " + newName + " "
-                "name can't currently contain any spaces!",
-                PLATYPUS_CURRENT_FUNC_NAME,
-                Debug::MessageType::PLATYPUS_ERROR
-            );
-            PLATYPUS_ASSERT(false);
-        }
-        #ifdef PLATYPUS_DEBUG
-        if (_nameEntityMapping.find(newName) != _nameEntityMapping.end())
-        {
-            Debug::log(
-                "Entity name " + newName + " already exists!",
-                PLATYPUS_CURRENT_FUNC_NAME,
-                Debug::MessageType::PLATYPUS_ERROR
-            );
-            PLATYPUS_ASSERT(false);
-            return;
-        }
-        if (_nameEntityMapping.find(currentName) == _nameEntityMapping.end())
-        {
-            Debug::log(
-                "No entity name " + currentName + " found!",
-                PLATYPUS_CURRENT_FUNC_NAME,
-                Debug::MessageType::PLATYPUS_ERROR
-            );
-            PLATYPUS_ASSERT(false);
-            return;
-        }
-        #endif
-        size_t entityIndex = _nameEntityMapping[currentName];
-        _nameEntityMapping[newName] = entityIndex;
-        _nameEntityMapping.erase(currentName);
-    }
-
-    void Scene::addEntityName(entityID_t entity, const std::string& name)
-    {
-        if (_nameEntityMapping.find(name) != _nameEntityMapping.end())
-        {
-            Debug::log(
-                "Entity name " + name + " already exists!",
-                PLATYPUS_CURRENT_FUNC_NAME,
-                Debug::MessageType::PLATYPUS_ERROR
-            );
-            PLATYPUS_ASSERT(false);
-            return;
-        }
-        int64_t entityIndex = -1;
-        for (size_t i = 0; i < _entities.size(); ++i)
-        {
-            if (_entities[i].id == entity)
-            {
-                entityIndex = static_cast<int64_t>(i);
-                break;
-            }
-        }
-        if (entityIndex == -1)
-        {
-            Debug::log(
-                "Failed to find entity with entityID_t: " + std::to_string(entity),
-                PLATYPUS_CURRENT_FUNC_NAME,
-                Debug::MessageType::PLATYPUS_ERROR
-            );
-            PLATYPUS_ASSERT(false);
-            return;
-        }
-        _nameEntityMapping[name] = static_cast<size_t>(entityIndex);
+        _entityNameMapping[entity] = name;
     }
 
     void Scene::setEntityActive(entityID_t entity, bool arg)
@@ -368,21 +277,6 @@ namespace platypus
         return _entities[entity].id != NULL_ENTITY_ID;
     }
 
-    bool Scene::entityExists(const std::string& name) const
-    {
-        return _nameEntityMapping.find(name) != _nameEntityMapping.end();
-    }
-
-    std::vector<std::string> Scene::getEntityNames() const
-    {
-        std::vector<std::string> names;
-        std::unordered_map<std::string, size_t>::const_iterator it;
-        for (it = _nameEntityMapping.begin(); it != _nameEntityMapping.end(); ++it)
-            names.push_back(it->first);
-
-        return names;
-    }
-
     void Scene::destroyEntity(entityID_t entityID)
     {
         if (!isValidEntity(entityID, "destroyEntity"))
@@ -441,22 +335,9 @@ namespace platypus
         _entities[entityID].clear(_entityUUIDPool);
 
         // Free entity name
-        // TODO: Optimize!
-        std::unordered_map<std::string, size_t>::const_iterator nameIt;
-        std::string foundName;
-        for (nameIt = _nameEntityMapping.begin(); nameIt != _nameEntityMapping.end(); ++nameIt)
-        {
-            if (nameIt->second == entityID)
-            {
-                foundName = nameIt->first;
-                break;
-            }
-        }
-        if (!foundName.empty())
-        {
-            Debug::log("___TEST___ERASING ENTITY: '" + foundName + "'");
-            _nameEntityMapping.erase(foundName);
-        }
+        std::unordered_map<entityID_t, std::string>::iterator nameIt = _entityNameMapping.find(entityID);
+        if (nameIt != _entityNameMapping.end())
+            _entityNameMapping.erase(nameIt);
     }
 
     void Scene::destroyEntityHierarchy(entityID_t entityID)

--- a/platypus/core/Scene.cpp
+++ b/platypus/core/Scene.cpp
@@ -840,8 +840,7 @@ namespace platypus
         for (entityID_t entityID : toSerialize)
         {
             const Entity& entity = getEntity(entityID);
-            const std::string entityName = getEntityName(entity.id);
-            std::vector<char> entityData = serialize_entity(entity, getEntityName(entityID));
+            std::vector<char> entityData = serialize_entity(this, entity);
             serializedData.resize(serializedData.size() + entityData.size());
             memcpy(serializedData.data() + pos, entityData.data(), entityData.size());
             pos += entityData.size();
@@ -849,7 +848,7 @@ namespace platypus
             std::unordered_map<ComponentType, const void*> components = getComponents(entityID);
             Debug::log(
                 "___TEST___serializing " + std::to_string(components.size()) + " components "
-                "for entity: '" + entityName + "'"
+                "for entity: '" + getEntityName(entity.id) + "'"
             );
             std::unordered_map<ComponentType, const void*>::const_iterator it;
             for (it = components.begin(); it != components.end(); ++it)
@@ -903,18 +902,19 @@ namespace platypus
         size_t& bufferReadEndPos
     )
     {
+        const char* pData = serializedData.data();
+
         const size_t serializedDataSize = serializedData.size();
         size_t beginReadPos = bufferReadPos;
-        PLATYPUS_ASSERT((bufferReadPos + serialized_entity_size) <= serializedDataSize);
-        const char* pData = serializedData.data();
+
         Entity entity;
         deserialize_entity(
             this,
             entity,
-            serialized_entity_size,
             pData + bufferReadPos
         );
-        bufferReadPos += serialized_entity_size;
+        bufferReadPos += get_serialized_entity_size(this, entity);
+        PLATYPUS_ASSERT(bufferReadPos <= serializedData.size());
 
         const size_t componentCount = get_component_count(entity.componentMask);
         Debug::log(
@@ -969,7 +969,6 @@ namespace platypus
     )
     {
         const size_t serializedDataSize = serializedData.size();
-        PLATYPUS_ASSERT((serializedDataPos + sizeof(uint32_t)) <= serializedDataSize);
         const char* pData = serializedData.data() + serializedDataPos;
         uint32_t entityCount = 0;
         memcpy(
@@ -986,10 +985,9 @@ namespace platypus
             deserialize_entity(
                 this,
                 entity,
-                serialized_entity_size,
                 pData + pos
             );
-            pos += serialized_entity_size;
+            pos += get_serialized_entity_size(this, entity);
 
             size_t componentCount = get_component_count(entity.componentMask);
             for (size_t componentIndex = 0; componentIndex < componentCount; ++componentIndex)

--- a/platypus/core/Scene.hpp
+++ b/platypus/core/Scene.hpp
@@ -31,7 +31,8 @@ namespace platypus
 
         std::vector<System*> _systems;
         std::vector<Entity> _entities;
-        std::unordered_map<std::string, size_t> _nameEntityMapping;
+
+        std::unordered_map<entityID_t, std::string> _entityNameMapping;
 
         std::queue<entityID_t> _freeEntityIDs;
         // NOTE: I don't like these being heap allocated, but want to get this just working for now...
@@ -61,22 +62,13 @@ namespace platypus
         entityID_t createEntity(const std::string& name = "", UUID_t explicitUUID = NULL_UUID);
         Entity getEntity(entityID_t entity) const;
         Entity getEntity(UUID_t entityUUID) const;
-        Entity getEntity(const std::string& name) const;
         std::string getEntityName(entityID_t entity) const;
-        void setEntityName(const std::string& currentName, const std::string& newName);
-        // Used to add new name for entity, if doesn't have one yet
-        void addEntityName(entityID_t entity, const std::string& name);
+        void setEntityName(entityID_t entity, const std::string& name);
         void setEntityActive(entityID_t entity, bool arg);
         bool isEntityActive(entityID_t entity) const;
         bool entityExists(entityID_t entity) const;
-        bool entityExists(const std::string& name) const;
         inline const std::vector<Entity>& getEntities() const { return _entities; }
-        // TODO:
-        // *Make getEntityNames() safer!
-        // *Get rid of getEntityNames() when figuring out some more coherent system with
-        // entity names!
-        // NOTE: getEntityNames() is slow as fuck! DO NOT RELY ON THIS AT "SCENE RUNTIME"
-        std::vector<std::string> getEntityNames() const;
+
         void destroyEntity(entityID_t entityID);
         void destroyEntityHierarchy(entityID_t entityID);
         void destroyComponent(entityID_t entityID, ComponentType componentType);

--- a/platypus/ecs/Entity.cpp
+++ b/platypus/ecs/Entity.cpp
@@ -103,40 +103,57 @@ namespace platypus
         return count;
     }
 
-
-    std::vector<char> serialize_entity(const Entity& entity, const std::string& entityName)
+    size_t get_serialized_entity_size(const Scene* pScene, const Entity& entity)
     {
-        size_t nameSize = entityName.size();
-        PLATYPUS_ASSERT(nameSize <= serialized_entity_name_size);
+        const std::string name = pScene->getEntityName(entity.id);
+        return serialized_entity_base_size + name.size();
+    }
 
-        std::vector<char> serializedData(serialized_entity_size);
-        memset(serializedData.data(), 0, serialized_entity_size);
+    std::vector<char> serialize_entity(
+        const Scene* pScene,
+        const Entity& entity
+    )
+    {
+        const size_t serializedSize = get_serialized_entity_size(pScene, entity);
+        std::vector<char> serializedData(serializedSize);
+        char* pBuf = serializedData.data();
         memcpy(
-            serializedData.data(),
+            pBuf,
             &entity.uuid,
             sizeof(UUID_t)
         );
         size_t pos = sizeof(UUID_t);
 
         memcpy(
-            serializedData.data() + pos,
+            pBuf + pos,
             &entity.componentMask,
             sizeof(uint64_t)
         );
         pos += sizeof(uint64_t);
 
         memcpy(
-            serializedData.data() + pos,
+            pBuf + pos,
             &entity.active,
             sizeof(uint8_t)
         );
         pos += sizeof(uint8_t);
 
+        const std::string name = pScene->getEntityName(entity.id);
+        const uint32_t nameSizeU32 = static_cast<const uint32_t>(name.size());
         memcpy(
-            serializedData.data() + pos,
-            entityName.data(),
-            nameSize
+            pBuf + pos,
+            &nameSizeU32,
+            sizeof(uint32_t)
         );
+        pos += sizeof(uint32_t);
+
+        memcpy(
+            pBuf + pos,
+            name.data(),
+            name.size()
+        );
+        pos += name.size();
+        PLATYPUS_ASSERT(pos == serializedSize);
 
         return serializedData;
     }
@@ -145,17 +162,11 @@ namespace platypus
     void deserialize_entity(
         Scene* pScene,
         Entity& outEntity,
-        size_t dataSize,
         const void* pData
     )
     {
-        PLATYPUS_ASSERT(dataSize == serialized_entity_size);
-
+        const char* pBuf = reinterpret_cast<const char*>(pData);
         UUID_t uuid;
-        uint64_t componentMask;
-        uint8_t active;
-        char name[serialized_entity_name_size];
-
         memcpy(
             &uuid,
             pData,
@@ -163,34 +174,53 @@ namespace platypus
         );
         size_t pos = sizeof(UUID_t);
 
+        uint64_t componentMask;
         memcpy(
             &componentMask,
-            reinterpret_cast<const char*>(pData) + pos,
+            pBuf + pos,
             sizeof(uint64_t)
         );
         pos += sizeof(uint64_t);
 
+        uint8_t active;
         memcpy(
             &active,
-            reinterpret_cast<const char*>(pData) + pos,
+            pBuf + pos,
             sizeof(uint8_t)
         );
         pos += sizeof(uint8_t);
 
+        uint32_t nameSizeU32 = 0;
         memcpy(
-            name,
-            reinterpret_cast<const char*>(pData) + pos,
-            serialized_entity_name_size
+            &nameSizeU32,
+            pBuf + pos,
+            sizeof(uint32_t)
         );
-        std::string nameStr(name);
+        pos += sizeof(uint32_t);
+
+        const size_t nameSize = static_cast<const size_t>(nameSizeU32);
+        std::string name;
+        if (nameSize > 0)
+        {
+            char* pNameData = new char[nameSize];
+            memcpy(
+                pNameData,
+                pBuf + pos,
+                nameSize
+            );
+            pos += nameSize;
+            name = std::string(pNameData, nameSize);
+            delete[] pNameData;
+        }
 
         // NOTE: atm assuming that all written entities are in correct order
         //  -> scene assigns the id
         //  TODO: Add names for serialized entities!
-        entityID_t entityID = pScene->createEntity(nameStr, uuid);
+        entityID_t entityID = pScene->createEntity(name, uuid);
         pScene->setComponentMask(entityID, componentMask);
         pScene->setEntityActive(entityID, static_cast<bool>(active));
         outEntity = pScene->getEntity(uuid);
+        PLATYPUS_ASSERT(pos == get_serialized_entity_size(pScene, outEntity));
     }
 
 

--- a/platypus/ecs/Entity.hpp
+++ b/platypus/ecs/Entity.hpp
@@ -13,12 +13,11 @@ namespace platypus
 {
     class Scene;
 
-    constexpr size_t serialized_entity_name_size = 64;
-    constexpr size_t serialized_entity_size =
+    constexpr size_t serialized_entity_base_size =
         sizeof(UUID_t) +
-        sizeof(uint64_t) +
-        sizeof(uint8_t) +
-        serialized_entity_name_size;
+        sizeof(uint64_t) + // component mask
+        sizeof(uint8_t) + // active
+        sizeof(uint32_t); // name size
 
     constexpr size_t serialized_entities_header_size = sizeof(uint32_t);
 
@@ -63,14 +62,16 @@ namespace platypus
     // NOTE: Doesn't work if the mask value's size changes!
     size_t get_component_count(uint64_t componentMask);
 
+    size_t get_serialized_entity_size(const Scene* pScene, const Entity& entity);
     // NOTE:
     // *entityID_t not included in serialized format, ONLY THE UUID!
-    // *Should we rather return the UUID instead of the entityID_t here?
-    std::vector<char> serialize_entity(const Entity& entity, const std::string& entityName);
+    std::vector<char> serialize_entity(
+        const Scene* pScene,
+        const Entity& entity
+    );
     void deserialize_entity(
         Scene* pScene,
         Entity& outEntity,
-        size_t dataSize,
         const void* pData
     );
 


### PR DESCRIPTION
*Allow multiple entities to have same name
*Made serialized entity name size be any size instead of strict 64 bytes
*Forced to use entityIDs instead of their names